### PR TITLE
update matplotlib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ requirements = [
     'tensorflow==1.10.0',
     'numpy==1.14.5',
     'pandas==0.23.1',
-    'matplotlib==2.1.1',
+    'matplotlib==3.0.0',
     'h5py==2.8.0',
     'pyspark==2.3.1',
     'pyarrow==0.8.0'       # required by pyspark


### PR DESCRIPTION
matplotlib below 3.0.0 will automatically use a backend that requires GUI extensions (like tkinter) to be installed, which are not installed (and are actually considerably difficult to install) on amazon linux, as used by EMR. 

matplotlib 3.0.0 will detect backends and use a headless version when there is no display available, removing the need for tkinter to be installed

cc @davidagold 