### PR TITLE
allow model and metadata to have the same base name

### DIFF
--- a/trace_classifier/load.py
+++ b/trace_classifier/load.py
@@ -106,7 +106,7 @@ def load_model_metadata(model_path):
         # Model is in the form of: <model_name>_some_other_strings.pb
         # Search for model name by cutting off the filename part by part
         parts = model_name.split("_")
-        for i in range(len(parts) - 1, -1, -1):
+        for i in range(len(parts), -1, -1):
             model_name = "_".join(parts[:i])
             metadata_file = os.path.join(saved_model_dir, model_name + "_metadata.json")
             if os.path.exists(metadata_file):


### PR DESCRIPTION
previously, if your model was named `trace_classifier_optimised_frozen.pb`, you could not have metadata named `trace_classifier_optimised_frozen_metadata.json`; the last word of the model filename was always dropped so the closest metadata name allowed was `trace_classifier_optimised_metadata.json`